### PR TITLE
fix: steamrip scraper freezing whole manager on second search and update notification

### DIFF
--- a/src/data/hosts/megadb.py
+++ b/src/data/hosts/megadb.py
@@ -17,13 +17,17 @@ def show_megadb_notification():
                                            text="Beware of malicious Ads. Make sure to have an adblocker installed.\n" '<br><a href="https://ublockorigin.com">Visit uBlock Origin</a>',
                                            darkmode=False if state.window_transparency else True
                                            )
+
     notification_popup.setTextFormat(Qt.TextFormat.RichText)
     notification_popup.setTextInteractionFlags(Qt.TextInteractionFlag.TextBrowserInteraction)
+
     if state.window_transparency is True:
         notification_popup.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
+
     button = notification_popup.addButton("Don't show again", QMessageBox.ButtonRole.AcceptRole)
     button.clicked.connect(lambda: setattr(state, "show_megadb_notification", False))
-    save_settings(show_megadb_notification=False)
+    
+    save_settings(show_megadb_notification=state.show_megadb_notification)
     notification_popup.exec()
 
 def scrape_megadb(url):

--- a/src/data/sources/steamrip.py
+++ b/src/data/sources/steamrip.py
@@ -9,23 +9,22 @@ import webbrowser
 import requests
 import time
 import re
+import copy
 
 class SteamripScraper:
     name = "steamrip"
     headers = ["Game"]
     is_magnet = False
 
-
     def __init__(self):
         self.cache = { "data": [], "last_fetched": 0 }
         self.cache_expiry = 300
 
     def scrape_steamrip_links(self):
-        
         current_time = time.time()
 
-        if self.cache["data"] != [] and (current_time - self.cache["last_fetched"] < self.cache_expiry):
-            return self.cache["data"]
+        if self.cache["data"] and (current_time - self.cache["last_fetched"] < self.cache_expiry):
+            return copy.deepcopy(self.cache["data"])
 
         try:
             url = f"https://steamrip.com/games-list-page/"
@@ -71,7 +70,7 @@ class SteamripScraper:
 
         soup = BeautifulSoup(response.text, "html.parser")
         download_link_elements = soup.find_all("a",class_="shortc-button")
-        download_links = ["buzzheavier", "gofile", "vikingfile", "megadb"]
+        download_links = ["", "", "", ""]
 
         for download_link in download_link_elements:
             pure = download_link.attrs.get("href")
@@ -89,7 +88,7 @@ class SteamripScraper:
         ret = []
 
         for link in download_links:
-            if len(link) != 1:
+            if link != "":
                 ret.append(link)
 
         return ret

--- a/src/interface/dialogs/notificationpopup.py
+++ b/src/interface/dialogs/notificationpopup.py
@@ -1,4 +1,5 @@
 from PySide6.QtWidgets import QMessageBox
+from utils.data.state import state
 import qdarktheme
 
 class NotificationPopup(QMessageBox):
@@ -6,7 +7,10 @@ class NotificationPopup(QMessageBox):
         super().__init__(parent)
 
         if darkmode is True:
-            qdarktheme.setup_theme("auto")
+            custom_colors = {}
+            if state.accent_color:
+                custom_colors["primary"] = state.accent_color
+            qdarktheme.setup_theme("auto", custom_colors=custom_colors if custom_colors else None)
 
         self.setIcon(QMessageBox.Icon.Information)
         self.setWindowTitle(title)


### PR DESCRIPTION
This pull request introduces several improvements and fixes related to notifications, UI theming, and the Steamrip scraper's caching and download link handling. The main changes enhance user experience by ensuring correct settings persistence, customizable theme colors, and more robust handling of cached data and download links.

**Notification and UI improvements:**
* [`src/interface/dialogs/notificationpopup.py`](diffhunk://#diff-e2493f8d6f69ebb9d04556d96e875f8f80eda9c78a822c5d25a15339a227e5b4R2-R13): Added support for a customizable accent color in dark mode by passing `state.accent_color` to `qdarktheme.setup_theme`, improving UI theming consistency.
* [`src/data/hosts/megadb.py`](diffhunk://#diff-8ebbd3e9b28c6b62a96ea56e71fe37dc0be117e600798b0d874e58e9e24eca19R20-R30): Fixed the persistence of the "Don't show again" notification setting by saving the current value of `state.show_megadb_notification` instead of always setting it to `False`.

**Steamrip scraper improvements:**
* [`src/data/sources/steamrip.py`](diffhunk://#diff-edff65adbb522f6af882da6d8818d84a910b921385f9f5fa691d5a5c8d3087a5R12-R27): Changed cache return logic to use a deep copy (`copy.deepcopy`) of cached data, preventing accidental mutation of the cache by consumers.
* [`src/data/sources/steamrip.py`](diffhunk://#diff-edff65adbb522f6af882da6d8818d84a910b921385f9f5fa691d5a5c8d3087a5L74-R73): Updated download link handling to initialize `download_links` as a list of empty strings and filter out empty strings instead of checking link length, improving robustness and clarity in `scrape_steamrip_game_downloads`. [[1]](diffhunk://#diff-edff65adbb522f6af882da6d8818d84a910b921385f9f5fa691d5a5c8d3087a5L74-R73) [[2]](diffhunk://#diff-edff65adbb522f6af882da6d8818d84a910b921385f9f5fa691d5a5c8d3087a5L92-R91)…ate notification popup settings and improve megadb notification handling