### PR TITLE
fix: steamrip provider indexing

### DIFF
--- a/src/data/sources/steamrip.py
+++ b/src/data/sources/steamrip.py
@@ -110,23 +110,19 @@ class SteamripScraper:
             consoleLog("SteamRip: No valid download links found")
             return None, None
 
-        try:
-            idx = links.index(best)
-        except ValueError:
-            consoleLog("SteamRip: Failed to resolve download host")
-            return None, None
 
         try:
-            if idx == 0:
+            consoleLog(f"Found download link: {best}")
+            if "buzzheavier" in best:
                 link = scrape_buzzheavier(best)
                 return link
-            elif idx == 1:
+            elif "gofile" in best:
                 link, headers = scrape_gofile(best)
                 return link, headers
-            elif idx == 2:
+            elif "vikingfile" in best:
                 scrape_vikingfile(best)
                 return None, None
-            elif idx == 3:
+            elif "megadb" in best:
                 scrape_megadb(best)
                 return None, None
             else:


### PR DESCRIPTION
Replace brittle index-based host resolution in SteamripScraper with substring checks on the chosen download URL (buzzheavier, gofile, vikingfile, megadb). Add a console log for the resolved link and adjust returned values for gofile. Remove the unnecessary links.index lookup and its exception handling.