### PR TITLE
Feat/crossplatform updatecheck

### DIFF
--- a/src/interface/dialogs/settings.py
+++ b/src/interface/dialogs/settings.py
@@ -79,9 +79,8 @@ def settings_dialog(self):
 
     # Ignore Updates checkbox
     update_checkbox_container, update_checkbox = create_widget(QCheckBox, "Ignore Updates: ")
-    if platform.system() == "Windows":
-        update_checkbox.setChecked(state.ignore_updates)
-        update_checkbox.toggled.connect(lambda checked: setattr(state, 'ignore_updates', checked))
+    update_checkbox.setChecked(state.ignore_updates)
+    update_checkbox.toggled.connect(lambda checked: setattr(state, 'ignore_updates', checked))
 
     # Autoresume Container Checkbox
     autoresume_container, autoresume_checkbox = create_widget(QCheckBox, "Auto-Resume Downloads: ")

--- a/src/interface/dialogs/update.py
+++ b/src/interface/dialogs/update.py
@@ -1,5 +1,5 @@
+from PySide6.QtWidgets import QDialog, QMessageBox, QCheckBox
 from utils.network.update_checker import get_updates
-from PySide6.QtWidgets import QDialog, QMessageBox, QCheckBox, QDialogButtonBox, QVBoxLayout, QLabel
 from utils.network.updater import download_update
 from utils.config.config import create_config
 from utils.logging.logs import consoleLog

--- a/src/interface/dialogs/update.py
+++ b/src/interface/dialogs/update.py
@@ -1,12 +1,16 @@
 from utils.network.update_checker import get_updates
-from PySide6.QtWidgets import QDialog, QMessageBox
+from PySide6.QtWidgets import QDialog, QMessageBox, QCheckBox, QDialogButtonBox, QVBoxLayout, QLabel
 from utils.network.updater import download_update
+from utils.config.config import create_config
 from utils.logging.logs import consoleLog
 from utils.data.state import state
 from pathlib import Path
+import webbrowser
 import platform
 import json
 import os
+
+RELEASES_URL = "https://github.com/KeksPirates/SoftwareManager/releases/latest"
 
 def _get_build_info_path() -> (Path | None):
     current_dir = Path(__file__).resolve().parent
@@ -31,19 +35,49 @@ def get_version() -> None:
     else:
         consoleLog(f"Could not find build info file (Path: {build_info_path})")
 
+
+def _show_notify_dialog(latest: str) -> None:
+    msg = QMessageBox()
+    msg.setIcon(QMessageBox.Icon.Information)
+    msg.setWindowTitle("Update Available")
+    msg.setText(f"A new version is available: <b>{latest}</b>")
+    msg.setInformativeText("Visit the releases page to download it.")
+
+    dont_show = QCheckBox("Don't show again")
+    msg.setCheckBox(dont_show)
+
+    open_btn = msg.addButton("Open Releases Page", QMessageBox.ButtonRole.AcceptRole)
+    msg.addButton("Dismiss", QMessageBox.ButtonRole.RejectRole)
+
+    msg.exec()
+
+    if dont_show.isChecked():
+        state.ignore_updates = True
+        create_config()
+
+    if msg.clickedButton() == open_btn:
+        webbrowser.open(RELEASES_URL)
+
+
 class UpdateDialog(QDialog):
     def __init__(self, parent=None):
-        if state.ignore_updates is False and platform.system() == "Windows":
+        if state.ignore_updates:
+            return
 
-            assets, latest = get_updates()
-            if assets != None:
-                msg = QMessageBox()
-                msg.setIcon(QMessageBox.Icon.Information)
-                msg.setWindowTitle("Update Available")
-                msg.setText(f"A new version is available\n({latest})")
-                msg.setInformativeText("Press Ok to download.")
-                msg.setStandardButtons(QMessageBox.StandardButton.Ok | QMessageBox.StandardButton.Ignore)
-                response = msg.exec_()
-                if response == QMessageBox.StandardButton.Ok:
-                    download_update(assets)
+        assets, latest = get_updates()
+        if assets is None:
+            return
+
+        if platform.system() == "Windows":
+            msg = QMessageBox()
+            msg.setIcon(QMessageBox.Icon.Information)
+            msg.setWindowTitle("Update Available")
+            msg.setText(f"A new version is available\n({latest})")
+            msg.setInformativeText("Press Ok to download.")
+            msg.setStandardButtons(QMessageBox.StandardButton.Ok | QMessageBox.StandardButton.Ignore)
+            response = msg.exec_()
+            if response == QMessageBox.StandardButton.Ok:
+                download_update(assets)
+        else:
+            _show_notify_dialog(latest)
 


### PR DESCRIPTION
This pull request refactors and improves the update notification and handling logic in the settings and update dialogs. The main changes include introducing a unified, cross-platform update notification dialog, adding a "Don't show again" option, and cleaning up platform-specific code.

**Update notification improvements:**

* Added a new `_show_notify_dialog` function in `update.py` that displays an update notification dialog with a "Don't show again" checkbox and an "Open Releases Page" button. If the checkbox is checked, update notifications are suppressed in the future (`state.ignore_updates` is set and persisted). The dialog also opens the releases page in the browser if requested.
* The update notification now works on all platforms, not just Windows. The logic for displaying the update dialog is refactored to use `_show_notify_dialog` for non-Windows platforms and to respect the "ignore updates" state.

**Settings dialog cleanup:**

* Removed the unnecessary Windows-only check when creating the "Ignore Updates" checkbox in the settings dialog, making the option available on all platforms.

**Dependency and import updates:**

* Added missing imports for `QCheckBox`, `QDialogButtonBox`, `QVBoxLayout`, `QLabel`, and `webbrowser` in `update.py` to support the new dialog functionality.…ialog for cross-platform compatibility
This pull request improves the update notification logic in the application, streamlining how users are notified about new versions and adding better user controls for future update prompts. The most important changes are:

**Update Notification Logic Improvements:**

* Added a new `_show_notify_dialog` function in `src/interface/dialogs/update.py` to display a user-friendly update notification dialog with options to open the releases page or dismiss, and a "Don't show again" checkbox to suppress future notifications (`[[1]](diffhunk://#diff-7f9f75cfbf84f8dc1ff161888c6ec048025c6ed78350c57747b0cb8a0df7670eR1-R14)`, `[[2]](diffhunk://#diff-7f9f75cfbf84f8dc1ff161888c6ec048025c6ed78350c57747b0cb8a0df7670eR38-R71)`).
* Changed the logic in the `UpdateDialog` class so that if `state.ignore_updates` is set, the update dialog does not show at all, regardless of platform (`[src/interface/dialogs/update.pyR38-R71](diffhunk://#diff-7f9f75cfbf84f8dc1ff161888c6ec048025c6ed78350c57747b0cb8a0df7670eR38-R71)`).
* Refactored the update dialog logic to use the new notification dialog for non-Windows platforms, while still providing the download option on Windows (`[src/interface/dialogs/update.pyR81-R82](diffhunk://#diff-7f9f75cfbf84f8dc1ff161888c6ec048025c6ed78350c57747b0cb8a0df7670eR81-R82)`).

**Configuration and State Management:**

* When the "Don't show again" checkbox is checked, the user's preference is saved to the configuration using `create_config()` and the `state.ignore_updates` flag (`[src/interface/dialogs/update.pyR38-R71](diffhunk://#diff-7f9f75cfbf84f8dc1ff161888c6ec048025c6ed78350c57747b0cb8a0df7670eR38-R71)`).

**Code Cleanup:**

* Removed an unnecessary platform check in `src/interface/dialogs/settings.py` when initializing the "Ignore Updates" checkbox, ensuring the setting is always correctly restored (`[src/interface/dialogs/settings.pyL82](diffhunk://#diff-871f9df982e9d462a736e7d5a50a65ef58a7ff055f6e6dcc5a5b75826696e423L82)`).